### PR TITLE
Removing explicit Types:[] declaration as this restricts what is comp…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "pretty": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["jest"],
     // Ensure that .d.ts files are created by tsc, but not .js files
     "declaration": true,
     //"emitDeclarationOnly": true,


### PR DESCRIPTION
…iled into the npm package. Explitly calling our types: [jest] ONLY includes @types/jest in the npm package.tgz. This conflicted with code needing @types/color. All @types/* modules are included if you do NOT explicitly declare a value in the types[] inside tsconfig.json.

    See link further details: https://www.typescriptlang.org/tsconfig#types