### PR TITLE
Issues with clear formatting in TIPTAP

### DIFF
--- a/src/applyMark.ts
+++ b/src/applyMark.ts
@@ -325,17 +325,17 @@ export function updateToggleMarks(
       if (pos <= _startPos) {
         const overrideMarkType = schema.marks[MARK_OVERRIDE];
         if (hasMarks) {
-          tr.removeMark(pos, pos + node.nodeSize, overrideMarkType);
+          tr.removeMark(pos, endPos.pos, overrideMarkType);
         }
         switch (markType.name) {
           case 'strong':
-            attrs = {strong: style?.styles?.strike ?? true};
+            attrs = { strong: style?.styles?.strong ?? true };
             break;
           case 'em':
-            attrs = {em: style?.styles?.strike ?? true};
+            attrs = { em: style?.styles?.em ?? true };
             break;
           case 'underline':
-            attrs = {underline: style?.styles?.strike ?? true};
+            attrs = { underline: style?.styles?.underline ?? true };
             break;
           case 'strike':
             attrs = {strike: style?.styles?.strike ?? true};
@@ -348,7 +348,7 @@ export function updateToggleMarks(
           if (overridenMark) {
             attrs = {...overridenMark.attrs, ...attrs};
           }
-          tr.addMark(pos, pos + node.nodeSize, overrideMarkType?.create(attrs));
+          tr.addMark(_startPos, endPos.pos, overrideMarkType?.create(attrs));
         }
       }
     }

--- a/src/clearMarks.test.ts
+++ b/src/clearMarks.test.ts
@@ -492,6 +492,85 @@ describe('clearMarks', () => {
       expect(clearmarks).toBeTruthy();
     });
   });
+
+  it('clearMarks: should return tr when slice has multiple children containing a non-Normal/non-null styleName paragraph', () => {
+  const mySchema2 = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: {
+        content: 'text*',
+        group: 'block',
+        attrs: { styleName: { default: null } },
+        toDOM: () => ['p', 0],
+      },
+      text: { group: 'inline' },
+    },
+    marks: {
+      strong: { toDOM: () => ['strong'] },
+    },
+  });
+
+  const doc1 = mySchema2.node('doc', null, [
+    mySchema2.node('paragraph', { styleName: 'header1' }, [mySchema2.text('Hello')]),
+    mySchema2.node('paragraph', { styleName: 'header2' }, [mySchema2.text('World')]),
+  ]);
+
+  // Build a real TextSelection so slice is produced with childCount > 1
+  const state = EditorState.create({ doc: doc1 });
+  const sel = TextSelection.create(doc1, 1, doc1.content.size - 1);
+  const tr = state.tr;
+  tr.setSelection(sel);
+
+  const result = clearMarks(tr, mySchema2);
+  expect(result).toBe(tr);
+});
+
+it('clearMarks: should call addMark when marksToAdd is populated (MARK_TEXT_COLOR overridden)', () => {
+  const mySchema2 = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: {
+        content: 'text*',
+        group: 'block',
+        attrs: { styleName: { default: null } },
+        toDOM: () => ['p', 0],
+      },
+      text: { group: 'inline' },
+    },
+    marks: {
+      'mark-text-color': {
+        attrs: { color: { default: '#000000' }, overridden: { default: false } },
+        toDOM: () => ['span'],
+      },
+    },
+  });
+
+  const doc1 = mySchema2.node('doc', null, [
+    mySchema2.node('paragraph', { styleName: null }, [
+      mySchema2.text('Hello', [
+        mySchema2.marks['mark-text-color'].create({ color: '#ff0000', overridden: true }),
+      ]),
+    ]),
+  ]);
+
+  const addMarkCalls: unknown[] = [];
+  const removeMarkCalls: unknown[] = [];
+  const fakeTr = {
+    doc: doc1,
+    selection: { empty: false, from: 0, to: doc1.content.size },
+    removeMark: (...args: unknown[]) => {
+      removeMarkCalls.push(args);
+      return fakeTr;
+    },
+    addMark: (...args: unknown[]) => {
+      addMarkCalls.push(args);
+      return fakeTr;
+    },
+  } as unknown as Transform;
+
+  clearMarks(fakeTr, mySchema2);
+  expect(addMarkCalls.length).toBeGreaterThan(0);
+});
 });
 describe('comapreMarks', () => {
   it('should handle comapreMarks', () => {

--- a/src/clearMarks.ts
+++ b/src/clearMarks.ts
@@ -39,6 +39,8 @@ const FORMAT_MARK_NAMES = [
   MARK_SUPER,
 ];
 
+type StyleObject = Record<string, unknown>;
+
 export function clearMarks(tr: Transform, schema: Schema): Transform {
   const { doc, selection } = tr as Transaction;
   if (!selection || !doc) {
@@ -88,7 +90,6 @@ export function clearMarks(tr: Transform, schema: Schema): Transform {
       node.marks.some((mark) => {
         if (mark?.type?.name === MarkNames.MARK_OVERRIDE) {
           overrideMarkstoRemove.push({ node, from: pos, to: pos + node.nodeSize, mark });
-          addOverrideMarksToNode(mark, marksToAdd, pos, node, schema);
 
         } else if (comapreMarks(style, mark, marksToAdd, pos, node, schema)) {
           if (markTypesToRemove.has(mark.type)) {
@@ -96,6 +97,8 @@ export function clearMarks(tr: Transform, schema: Schema): Transform {
           }
         }
       });
+      const styleMarks = getMissingMarks_Styles(style?.styles, node.marks);
+      AddMissingMarks_Styles(styleMarks, marksToAdd, pos, node, schema);
 
     }
     return true;
@@ -205,13 +208,47 @@ export function comapreMarks(style: Style, mark: Mark, marksToAdd, pos: number, 
   }
 }
 
-function addOverrideMarksToNode(mark: Mark, marksToAdd, pos: number, node: Node, schema: Schema) {
-  for (const key in mark.attrs) {
-    if (mark.attrs[key]) {
-      const markType = schema.marks[key];
-      marksToAdd.push({ node, from: pos, to: pos + node.nodeSize, markType });
-    }
+function getMissingMarks_Styles(
+  styleObj: StyleObject,
+  marks: readonly Mark[]
+): string[] {
+  if (styleObj) {
+    const availableTypes = new Set(marks.map(m => m.type.name));
+
+    return Object.entries(styleObj)
+      .filter(
+        ([key, value]) =>
+          typeof value === 'boolean' &&
+          !availableTypes.has(key)
+      )
+      .map(([key]) => key);
   }
+  return [];
+}
+
+function AddMissingMarks_Styles(styleMarks: string[], marksToAdd, pos: number, node: Node, schema: Schema) {
+
+  styleMarks?.forEach((styleKey) => {
+    const markType = schema.marks[styleKey];
+    if (!markType) return;
+
+    switch (markType.name) {
+      case MarkNames.MARK_STRONG:
+      case MarkNames.MARK_EM:
+      case MarkNames.MARK_UNDERLINE:
+      case MarkNames.MARK_STRIKE:
+        marksToAdd.push({
+          node,
+          from: pos,
+          to: pos + node.nodeSize,
+          markType: markType,
+          attrs: {}
+        });
+        break;
+      default:
+        break;
+    }
+  });
 
 }
 


### PR DESCRIPTION
1. issue of Clear Format incorrectly adding Bold / Italic when those exist elsewhere in the paragraph.
2. Clear format does not remove applied formats.